### PR TITLE
Fix classifier for .NET/C# PRs

### DIFF
--- a/build/utils/publish-classifier.js
+++ b/build/utils/publish-classifier.js
@@ -5,7 +5,7 @@ const GENERAL_TOPICS = [
 
 const VERSION_PREFIX_REGEX = /^[\(\[][34]\.[0-9x][\)\]]/;
 const VERSION_SUFFIX_REGEX = /[\(\[][34]\.[0-9x][\)\]]$/;
-const AREA_PREFIX_REGEX = /^[\[`']([a-zA-Z0-9]+)[\]`']/;
+const AREA_PREFIX_REGEX = /^[\[`']([a-zA-Z0-9\.#]+)[\]`']/;
 
 class PullClassifier {
     determineGroup(pull) {
@@ -123,6 +123,9 @@ class PullClassifier {
         // be slightly different than the group name.
         if (cleanMessage.startsWith("MP:")) {
             cleanMessage = cleanMessage.substring(3).trim();
+        }
+        if (cleanMessage.startsWith(".NET:")) {
+            cleanMessage = cleanMessage.substring(5).trim();
         }
         if (cleanMessage.startsWith("doc:")) {
             cleanMessage = cleanMessage.substring(4).trim();


### PR DESCRIPTION
The area prefix regex didn't include the `.` or `#` characters so it wasn't matching PRs with the prefix `[C#]` or `[.NET]`.

Also added a special case for `.NET` since some PRs use that as the prefix, but the classifier expects the group name `C#` instead.

| Before | After |
|-|-|
| ![](https://github.com/user-attachments/assets/81d62384-31f6-4b16-97ad-83f7ee10d798) | ![](https://github.com/user-attachments/assets/26261e64-4653-4539-960b-1a4c78772226) |
