### PR TITLE
Render inline code markup with code formatting

### DIFF
--- a/src/paths/index/components/changes/ReleaseNotesItem.js
+++ b/src/paths/index/components/changes/ReleaseNotesItem.js
@@ -140,11 +140,6 @@ export default class ReleaseNotesItem extends LitElement {
     constructor() {
         super();
 
-        // Configure marked renderer to treat backticks as bold
-        const renderer = new marked.Renderer();
-        renderer.codespan = (text) => `<strong>${text}</strong>`;
-        marked.setOptions({ renderer });
-
         this._viewMode = "pretty";
         this._groupMode = "grouped";
 

--- a/src/paths/index/components/changes/ReleaseNotesItem.js
+++ b/src/paths/index/components/changes/ReleaseNotesItem.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css, customElement, property } from 'lit-element';
+import marked from 'marked';
 
 @customElement('gr-release-notes')
 export default class ReleaseNotesItem extends LitElement {
@@ -139,6 +140,11 @@ export default class ReleaseNotesItem extends LitElement {
     constructor() {
         super();
 
+        // Configure marked renderer to treat backticks as bold
+        const renderer = new marked.Renderer();
+        renderer.codespan = (text) => `<strong>${text}</strong>`;
+        marked.setOptions({ renderer });
+
         this._viewMode = "pretty";
         this._groupMode = "grouped";
 
@@ -252,6 +258,11 @@ export default class ReleaseNotesItem extends LitElement {
         super.update(changedProperties);
     }
 
+    _parseMarkdown(text) {
+        // Parse markdown but only return the inner content without wrapping <p> tags
+        return marked(text).replace(/<\/?p>/g, '');
+    }
+
     _renderUnifiedItem(viewMode, item) {
         return (viewMode === "pretty" ? html`
             <li>
@@ -259,7 +270,7 @@ export default class ReleaseNotesItem extends LitElement {
                     ${item.group}:
                 </span>
                 <span>
-                    ${item.title}
+                    ${html([this._parseMarkdown(item.title)])}
                 </span>
                 <code>
                     (<a
@@ -279,7 +290,7 @@ export default class ReleaseNotesItem extends LitElement {
         return (viewMode === "pretty" ? html`
             <li>
                 <span>
-                    ${item.title}
+                    ${html([this._parseMarkdown(item.title)])}
                 </span>
                 <code>
                     (<a


### PR DESCRIPTION
Add support for rendering inline code markup in PR titles using `marked`.

* **ReleaseNotesItem.js**
  - Update the `title` property in the `_renderUnifiedItem` method to use `marked` for rendering.
  - Update the `title` property in the `_renderGroupedItem` method to use `marked` for rendering.

- Fixes #3 