### PR TITLE
Integrate `GRAPHQL_TOKEN` enhancements & checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Environment variables.
+.env
+
 # Project folders.
 node_modules/
 out/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You can supply your token to the scripts using the `GRAPHQL_TOKEN` environment
 variable. Note, that if you don't have member access to the organization, you
 may not be able to access all the information used when generating the database.
 
+> [!TIP]
+For convenience, it's recommended to store the `GRAPHQL_TOKEN` environment variable
+in a `.env` file at the repository root.
+
 ### Building the website
 
 1. Clone or download the project.

--- a/build/utils/compose-fetcher.js
+++ b/build/utils/compose-fetcher.js
@@ -161,6 +161,10 @@ class DataFetcher {
             init.headers["Authorization"] = `token ${process.env.GRAPHQL_TOKEN}`;
         } else if (process.env.GITHUB_TOKEN) {
             init.headers["Authorization"] = `token ${process.env.GITHUB_TOKEN}`;
+        } else {
+            console.error("    Unable to find environment variable: `GRAPHQL_TOKEN`. Did you forget to set it in your local environment or a root `.env` file?");
+            process.exitCode = buildCommon.ExitCodes.ParseFailure;
+            return [null, null];
         }
 
         init.body = JSON.stringify({
@@ -204,6 +208,10 @@ class DataFetcher {
             init.headers["Authorization"] = `token ${process.env.GRAPHQL_TOKEN}`;
         } else if (process.env.GITHUB_TOKEN) {
             init.headers["Authorization"] = `token ${process.env.GITHUB_TOKEN}`;
+        } else {
+            console.error("    Unable to find environment variable: `GRAPHQL_TOKEN`. Did you forget to set it in your local environment or a root `.env` file?");
+            process.exitCode = buildCommon.ExitCodes.ParseFailure;
+            return null;
         }
 
         return await fetch(`${this.api_rest_path}${query}`, init);
@@ -218,7 +226,9 @@ class DataFetcher {
             `;
 
             const [res, data] = await this.fetchGithub(query);
-            if (res.status !== 200 || data === null) {
+            if (res === null) {
+                return;
+            } else if (res.status !== 200 || data === null) {
                 this._handleResponseErrors(this.api_repository_id, res);
                 process.exitCode = buildCommon.ExitCodes.RequestFailure;
                 return;
@@ -323,7 +333,9 @@ class DataFetcher {
             console.log(`    Requesting batch ${page}/${totalPages} of commit and pull request data.`);
 
             const [res, data] = await this.fetchGithub(query, API_MAX_RETRIES);
-            if (res.status !== 200 || data === null) {
+            if (res === null) {
+                return;
+            } else if (res.status !== 200 || data === null) {
                 this._handleResponseErrors(this.api_repository_id, res);
                 process.exitCode = buildCommon.ExitCodes.RequestFailure;
                 return [];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "rollup -c",
-    "compose-db": "node ./compose-db.js",
+    "compose-db": "node --env-file-if-exists=./.env ./compose-db.js",
     "publish-db": "node ./publish-db.js"
   },
   "author": "Yuri Sizov <yuris@humnom.net>",


### PR DESCRIPTION
Streamlines the use of the `GRAPHQL_TOKEN` environment variable with the following tweaks:
- Enable the ability to store the variable within a git-ignored `.env`.
- Explicitly recommend the use of said file in the README.
- Add conditionals to assert the environment variable exists, with an appropriate error message if not.