### PR TITLE
composedb: Reduce commits per page to 50

### DIFF
--- a/compose-db.js
+++ b/compose-db.js
@@ -2,7 +2,7 @@ const DataFetcher = require('./build/utils/compose-fetcher.js');
 const DataProcessor = require('./build/utils/compose-processor.js');
 const DataIO = require('./build/utils/compose-io.js');
 
-const COMMITS_PER_PAGE = 150;
+const COMMITS_PER_PAGE = 50;
 
 async function main() {
     // Internal utility methods.


### PR DESCRIPTION
We've started getting HTTP error 502 on requests for 150 commits since one week.