### PR TITLE
Migrate deployment to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,60 @@
 name: Continuous integration
+on: [push, pull_request, workflow_dispatch]
 
-on:
-  push:
-    branches: [ master ]
-
-# Make sure jobs cannot overlap (e.g. one from push and one from schedule).
 concurrency:
-  group: pages-ci
+  group: ${{ github.workflow }}|${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: Build and deploy to GitHub Pages
+    name: 🛠️ Build
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
 
-    - name: Install Node.js 16.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 16.x
-        cache: 'npm'
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
 
-    - name: Build the static content using npm
-      run: npm run build
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Prepare and copy configuration and data
-      run: npm run publish-db
-      env:
-        GRAPHQL_TOKEN: ${{ secrets.GRAPHQL_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build the static content using npm
+        run: npm run build
 
-    - name: Archive production artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: web-static
-        path: out
+      - name: Prepare and copy configuration and data
+        run: npm run publish-db
+        env:
+          GRAPHQL_TOKEN: ${{ secrets.GRAPHQL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Deploy to GitHub Pages 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages
-        folder: out
-        # Configure the commit author.
-        git-config-name: 'Godot Organization'
-        git-config-email: '<>'
-        # Don't keep the history.
-        single-commit: true
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: out/
+
+  deploy:
+    name: 📤 Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref_name == github.event.repository.default_branch
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    concurrency:
+      group: ci-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
A (relatively) new feature to take advantage of on GitHub is the ability to deploy webpages directly via GitHub Actions[^1]. This means we no longer need `gh-pages` as a workaround; a site can be built and deployed within the same action. This eliminates a major annoyance of redundancy: the website no longer needs to be built/uploaded twice! While the redundant upload wasn't a concern for *this* repo, it absolutely would speed things up on the documentation & main site repositories.

Output logic can be observed on my fork through two actions: one for the default branch, and one on a standalone branch (the one used for this PR).
- [Default branch](https://github.com/Repiteo/godot-interactive-changelog/actions/runs/19936162361): Both uploads the built website as an artifact AND deploys the website to GitHub Pages. Pushes/merges to our default branch will operate as they always have, albeit a fair bit faster.
- [Standalone branch](https://github.com/Repiteo/godot-interactive-changelog/actions/runs/19936259731): Uploads the built website as an artifact, but does NOT deploy the website. The only branch that can deploy to the website is the default branch. This lets PRs have sanity-checks on their builds, but will **never** attempt a deployment.

The successfully deployed site on my repository can be viewed [here](https://repiteo.github.io/godot-interactive-changelog/). Note that my repository does not have a `gh-pages` branch[^2], so this is all handled by the action.

> [!IMPORTANT]  
> If this is approved, one adjustment to the settings **must** be made prior to merging: changing the website source from "Deploy from a branch" to "GitHub Actions". This is something I can actually achieve myself with the limited repository permissions I have available, but anyone with the power to do so can accomplish this

[^1]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
[^2]: https://github.com/Repiteo/godot-interactive-changelog/branches